### PR TITLE
Fix base of script number from octal to decimal to support script

### DIFF
--- a/toolchain.sh
+++ b/toolchain.sh
@@ -176,7 +176,7 @@ run_scripts ../depends dependency
 get_script_number ()
 {
 	NUM="$1"
-	NUM=$((NUM))
+	NUM=$((10#$NUM))
 	printf '%03d' "$NUM"
 	unset NUM
 }


### PR DESCRIPTION
numbers greater than 8 as argument to toolchain.sh